### PR TITLE
make NetworkItemInstanceDescriptor fields public

### DIFF
--- a/crates/protocol/src/version/v662/types/network_item_instance_descriptor.rs
+++ b/crates/protocol/src/version/v662/types/network_item_instance_descriptor.rs
@@ -4,11 +4,11 @@ use std::io::{Read, Write};
 
 #[derive(Clone, Debug)]
 pub struct NetworkItemInstanceDescriptor {
-    id: i32,
-    stack_size: Option<u16>,
-    aux_value: Option<u32>,
-    block_runtime_id: Option<i32>,
-    user_data_buffer: Option<Vec<u8>>,
+    pub id: i32,
+    pub stack_size: Option<u16>,
+    pub aux_value: Option<u32>,
+    pub block_runtime_id: Option<i32>,
+    pub user_data_buffer: Option<Vec<u8>>,
 }
 
 impl ProtoCodec for NetworkItemInstanceDescriptor {


### PR DESCRIPTION
We **need** that.