### PR TITLE
fix:  protocol packet field encodings

### DIFF
--- a/crates/protocol/src/version/v2168/packets/play_sound.rs
+++ b/crates/protocol/src/version/v2168/packets/play_sound.rs
@@ -1,11 +1,15 @@
 use crate::ProtoVersion;
+use bedrock_protocol_core::error::ProtoCodecError;
+use bedrock_protocol_core::{ProtoCodec, ProtoCodecVAR};
 use bedrock_macros::{ProtoCodec, packet};
+use std::io::{Read, Write};
+use std::marker::PhantomData;
 
 #[packet(id = 86)]
 #[derive(ProtoCodec, Clone, Debug)]
 pub struct PlaySoundPacket<V: ProtoVersion> {
     pub name: String,
-    pub position: V::NetworkBlockPosition,
+    pub position: PlaySoundPosition<V>,
     #[endianness(le)]
     pub volume: f32,
     #[endianness(le)]
@@ -14,4 +18,58 @@ pub struct PlaySoundPacket<V: ProtoVersion> {
     pub loop_count: i32,
     #[endianness(le)]
     pub server_sound_handle: Option<i64>,
+}
+
+/// PlaySound stores position as signed varint coordinates scaled by 8.
+#[derive(Clone, Debug)]
+pub struct PlaySoundPosition<V: ProtoVersion> {
+    pub x8: i32,
+    pub y8: i32,
+    pub z8: i32,
+    _version: PhantomData<fn() -> V>,
+}
+
+impl<V: ProtoVersion> PlaySoundPosition<V> {
+    pub const FIXED_POINT_SCALE: f32 = 8.0;
+
+    pub const fn from_raw_x8(x8: i32, y8: i32, z8: i32) -> Self {
+        Self {
+            x8,
+            y8,
+            z8,
+            _version: PhantomData,
+        }
+    }
+
+    pub fn as_block_coords(&self) -> (f32, f32, f32) {
+        (
+            self.x8 as f32 / Self::FIXED_POINT_SCALE,
+            self.y8 as f32 / Self::FIXED_POINT_SCALE,
+            self.z8 as f32 / Self::FIXED_POINT_SCALE,
+        )
+    }
+}
+
+impl<V: ProtoVersion> ProtoCodec for PlaySoundPosition<V> {
+    fn serialize<W: Write>(&self, stream: &mut W) -> Result<(), ProtoCodecError> {
+        <i32 as ProtoCodecVAR>::serialize(&self.x8, stream)?;
+        <i32 as ProtoCodecVAR>::serialize(&self.y8, stream)?;
+        <i32 as ProtoCodecVAR>::serialize(&self.z8, stream)?;
+
+        Ok(())
+    }
+
+    fn deserialize<R: Read>(stream: &mut R) -> Result<Self, ProtoCodecError> {
+        Ok(Self::from_raw_x8(
+            <i32 as ProtoCodecVAR>::deserialize(stream)?,
+            <i32 as ProtoCodecVAR>::deserialize(stream)?,
+            <i32 as ProtoCodecVAR>::deserialize(stream)?,
+        ))
+    }
+
+    fn size_hint(&self) -> usize {
+        <i32 as ProtoCodecVAR>::size_hint(&self.x8)
+            + <i32 as ProtoCodecVAR>::size_hint(&self.y8)
+            + <i32 as ProtoCodecVAR>::size_hint(&self.z8)
+    }
 }

--- a/crates/protocol/src/version/v2168/packets/player_auth_input.rs
+++ b/crates/protocol/src/version/v2168/packets/player_auth_input.rs
@@ -36,7 +36,7 @@ pub mod player_auth_input_packet {
     #[derive(ProtoCodec, Clone, Debug)]
     pub struct PerformItemStackRequestData<V: ProtoVersion> {
         #[endianness(var)]
-        pub client_request_id: u32,
+        pub client_request_id: i32,
         pub actions: Vec<V::ItemStackRequestActionType>,
         pub strings_to_filter: Vec<String>,
         pub strings_to_filter_origin: V::TextProcessingEventOrigin,

--- a/crates/protocol/src/version/v662/enums/soft_enum_update_type.rs
+++ b/crates/protocol/src/version/v662/enums/soft_enum_update_type.rs
@@ -1,9 +1,8 @@
 use bedrock_macros::ProtoCodec;
 
 #[derive(ProtoCodec, Clone, Debug)]
-#[enum_repr(u32)]
-#[enum_endianness(le)]
-#[repr(u32)]
+#[enum_repr(u8)]
+#[repr(u8)]
 pub enum SoftEnumUpdateType {
     Add = 0,
     Remove = 1,

--- a/crates/protocol/src/version/v662/packets/item_stack_request.rs
+++ b/crates/protocol/src/version/v662/packets/item_stack_request.rs
@@ -10,7 +10,7 @@ pub struct ItemStackRequestPacket<V: ProtoVersion> {
 #[derive(ProtoCodec, Clone, Debug)]
 pub struct RequestsEntry<V: ProtoVersion> {
     #[endianness(var)]
-    pub client_request_id: u32,
+    pub client_request_id: i32,
     pub actions: Vec<V::ItemStackRequestActionType>,
     pub strings_to_filter: Vec<String>,
     pub strings_to_filter_origin: V::TextProcessingEventOrigin,

--- a/crates/protocol/src/version/v662/packets/player_auth_input.rs
+++ b/crates/protocol/src/version/v662/packets/player_auth_input.rs
@@ -97,7 +97,7 @@ pub mod player_auth_input_packet {
     #[derive(ProtoCodec, Clone, Debug)]
     pub struct PerformItemStackRequestData<V: ProtoVersion> {
         #[endianness(var)]
-        pub client_request_id: u32,
+        pub client_request_id: i32,
         pub actions: Vec<ActionsEntry<V>>,
         pub strings_to_filter: Vec<String>,
         pub strings_to_filter_origin: V::TextProcessingEventOrigin,

--- a/crates/protocol/src/version/v662/packets/sub_chunk_request.rs
+++ b/crates/protocol/src/version/v662/packets/sub_chunk_request.rs
@@ -7,7 +7,5 @@ pub struct SubChunkRequestPacket<V: ProtoVersion> {
     #[endianness(var)]
     pub dimension_type: i32,
     pub center_pos: V::SubChunkPos,
-    #[vec_repr(u32)]
-    #[vec_endianness(le)]
     pub sub_chunk_pos_offsets: Vec<V::SubChunkPosOffset>,
 }

--- a/crates/protocol/src/version/v662/types/serialized_abilities_data.rs
+++ b/crates/protocol/src/version/v662/types/serialized_abilities_data.rs
@@ -8,6 +8,7 @@ pub struct SerializedAbilitiesData<V: ProtoVersion> {
     pub player_permissions: V::PlayerPermissionLevel,
     pub command_permissions: V::CommandPermissionLevel,
 
+    #[vec_repr(u8)]
     pub layers: Vec<SerializedLayer>,
 }
 

--- a/crates/protocol/src/version/v748/packets/player_auth_input.rs
+++ b/crates/protocol/src/version/v748/packets/player_auth_input.rs
@@ -108,7 +108,7 @@ pub mod player_auth_input_packet {
     #[derive(ProtoCodec, Clone, Debug)]
     pub struct PerformItemStackRequestData<V: ProtoVersion> {
         #[endianness(var)]
-        pub client_request_id: u32,
+        pub client_request_id: i32,
         pub actions: Vec<ActionsEntry<V>>,
         pub strings_to_filter: Vec<String>,
         pub strings_to_filter_origin: V::TextProcessingEventOrigin,

--- a/crates/protocol/src/version/v766/packets/player_auth_input.rs
+++ b/crates/protocol/src/version/v766/packets/player_auth_input.rs
@@ -116,7 +116,7 @@ pub mod player_auth_input_packet {
     #[derive(ProtoCodec, Clone, Debug)]
     pub struct PerformItemStackRequestData<V: ProtoVersion> {
         #[endianness(var)]
-        pub client_request_id: u32,
+        pub client_request_id: i32,
         pub actions: Vec<ActionsEntry<V>>,
         pub strings_to_filter: Vec<String>,
         pub strings_to_filter_origin: V::TextProcessingEventOrigin,

--- a/crates/protocol/src/version/v776/types/serialized_abilities_data.rs
+++ b/crates/protocol/src/version/v776/types/serialized_abilities_data.rs
@@ -8,6 +8,7 @@ pub struct SerializedAbilitiesData<V: ProtoVersion> {
     // TODO: use enum with #[as(u8)] after proto refactor
     pub player_permissions: u8,
     pub command_permissions: V::CommandPermissionLevel,
+    #[vec_repr(u8)]
     pub layers: Vec<SerializedLayer>,
 }
 

--- a/crates/protocol/src/version/v944/packets/sync_world_clocks.rs
+++ b/crates/protocol/src/version/v944/packets/sync_world_clocks.rs
@@ -7,7 +7,7 @@ pub struct SyncWorldClocksPacket {
 }
 
 #[derive(ProtoCodec, Clone, Debug)]
-#[enum_endianness(le)]
+#[enum_endianness(var)]
 #[enum_repr(u32)]
 #[repr(u32)]
 pub enum SyncWorldClocks {
@@ -58,5 +58,5 @@ pub struct TimeMarker {
     #[endianness(var)]
     pub time: i32,
     #[endianness(var)]
-    pub period: i32,
+    pub period: Option<i32>,
 }


### PR DESCRIPTION
## Summary

Fix several packet field encoding mismatches from the protocol audit.

## Why

These fields were using the wrong wire representation for current Bedrock protocol data, causing encoded packets to diverge from the expected `vi32`, `vu32`, `u8`, optional or x8 fixed point formats.

## Changes

- Fix `ItemStackRequest` and embedded `PlayerAuthInput` request IDs to use signed `vi32`.
- Fix `SyncWorldClocks` discriminant to `vu32` and make `TimeMarker.period` optional.
- Fix `PlaySound.position` to use signed `vi32` x8 fixed point coordinates.
- Fix related count/discriminant encodings for `SubChunkRequest`, `UpdateSoftEnum` and `UpdateAbilities`.

 ## Breaking Changes

 - [ ] No
 - [x] Yes (describe below)

  Changes some public packet field types to match the protocol wire format.

  ## Related Issues

#232, #233, #235, #236, #237, #239

## Checklist

- [x] I kept the PR scope focused.
- [ ] I updated docs/examples when needed.
- [ ] I added or updated tests where relevant.